### PR TITLE
basic windows support

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -117,7 +117,14 @@ local function import_exs(path)
     return true
   end
 
-  local last_slash_pos = path:match"^.*()/"
+  if os.platform() == "WINDOWS" then
+    local last_slash_pos = path:match"^.*()\\"
+  else
+    local last_slash_pos = path:match"^.*()/"
+  end
+  if last_slash_pos == nil then
+    renoise.app():show_error("The EXS24 sample path could not be found")
+  end
   local instrument_filename = path:sub(last_slash_pos + 1)
   local instrument_path = path:sub(1, last_slash_pos)
 


### PR DESCRIPTION
Untested. 

Resolves #1.

You can test this patch with the attached .zip file. You will need to remove the .zip extension (so the filename is `com.matta.exs24.xrnx`) and install it like normal.

[com.matta.exs24.xrnx.zip](https://github.com/matt-allan/renoise-exs24/files/3668519/com.matta.exs24.xrnx.zip)