### PR TITLE
Two fixes required to import default GarageBand EXS24 instruments, Mac+Win tested

### DIFF
--- a/exs24.lua
+++ b/exs24.lua
@@ -32,7 +32,7 @@ function load_exs(path)
 
   while (i + 84 < data_size) do
     fh:seek("set", i)
-    local sig = read_dword(fh, big_endian)
+    local sig = read_dword(fh, false)
 
     fh:seek("set", i + 4)
     local size = read_dword(fh, big_endian)

--- a/main.lua
+++ b/main.lua
@@ -117,7 +117,12 @@ local function import_exs(path)
     return true
   end
 
-  local last_slash_pos = path:match"^.*()/"
+  -- determine which slash is in use
+  local slash = "/"
+  if path:find("\\") then
+    slash = "\\"
+  end
+  local last_slash_pos = path:match("^.*()"..slash)
   local instrument_filename = path:sub(last_slash_pos + 1)
   local instrument_path = path:sub(1, last_slash_pos)
 


### PR DESCRIPTION
I'm not too sure about why the sig value needs to be in little Endian.